### PR TITLE
Updates: fixed expire param

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Operations are named based on their request URIs as outlined in Mixpanel's [API 
 
 ```php
 //example client instantiation and API call
-$client = Mixpanel\MixpanelClient::factory(array(
+$client = MixGuzzle\MixGuzzleClient::factory(array(
     'key' => 'your_api_key',
     'secret' => 'your_api_secret'
 ));

--- a/src/MixGuzzle/Plugin/MixGuzzleAuthPlugin.php
+++ b/src/MixGuzzle/Plugin/MixGuzzleAuthPlugin.php
@@ -75,7 +75,7 @@ class MixGuzzleAuthPlugin implements EventSubscriberInterface{
         $request = $event['request'];
         $params = $request->getQuery()->getAll();
         $params['api_key'] = $this->apiKey;
-        $params['expire'] = (time() - date('Z')) + $this->expire; // Default 10 minutes
+        $params['expire'] = time() + $this->expire; // Default 10 minutes
 
         $params['sig'] = $this->signature($params);
         $url = Url::factory($request->getUrl())->setQuery('')->setFragment(NULL);

--- a/src/MixGuzzle/service.json
+++ b/src/MixGuzzle/service.json
@@ -183,6 +183,18 @@
                     "type": "string",
                     "description": "The specific bucket you would like to query.",
                     "required": false
+                },
+                "unit": {
+                    "location": "query",
+                    "type": "string",
+                    "description": "The granularity of returned data (minute, hour, day, week, or month)",
+                    "required": false
+                },
+                "interval": {
+                    "location": "query",
+                    "type": "integer",
+                    "description": "The number of units for which to return data, as defined by the units parameter",
+                    "required": false
                 }
             }
         },


### PR DESCRIPTION
Hey, I've fixed the 'expire' param in the request to use only the time() function, without timezone delay ( time() already returns UTC timestamp), so the lib can work in different timezones now. Also changed the namespace in the README description and added some params to the service description json file (they were not in the official mixpanel api doc, but they do work).

Would you mind merging?